### PR TITLE
On running tests in digital-land.info we're getting a deprecation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ __pycache__/
 .venv/
 
 build/
+
+.idea

--- a/digital_land_frontend/filters.py
+++ b/digital_land_frontend/filters.py
@@ -1,7 +1,7 @@
 import numbers
 import validators
 from datetime import datetime
-from jinja2 import Markup, evalcontextfilter
+from jinja2 import Markup, pass_eval_context
 
 
 def is_list_filter(v):
@@ -20,7 +20,7 @@ def is_valid_uri_filter(uri):
     return False
 
 
-@evalcontextfilter
+@pass_eval_context
 def make_link_filter(eval_ctx, url, **kwargs):
     """
     Converts a url string into an anchor element.


### PR DESCRIPTION
warning with regard to 'evalcontextfilter' saying to use 'pass_eval_context'
and that deprecated decorator will be removed in Jinja 3.1.