### PR TITLE
Register any filters found in filters module under name of the filter.

### DIFF
--- a/application/factory.py
+++ b/application/factory.py
@@ -57,4 +57,10 @@ def register_templates(app):
 
 
 def register_filters(app):
-    pass
+
+    import application.filters
+
+    for name, function in application.filters.__dict__.items():
+        if callable(function) and not name.startswith("__"):
+            app.add_template_filter(function, name=name)
+


### PR DESCRIPTION
Skip any funtions in module that are prefixed with "__", reserved for any internal helper functions.