### PR TITLE
Fixes JS copy scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digital-land-frontend-repo",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "description": "frontend components and assets for digital land",
   "engines": {
     "node": ">=16.0.0"

--- a/package/package-scripts.js
+++ b/package/package-scripts.js
@@ -21,8 +21,8 @@ scripts.build = {
 }
 
 scripts.copy = {
-  javascripts: `npx copyfiles "${configPaths.digitalLandFrontendPath}digital-land-frontend/javascripts/**/*.{js,json}" ${configPaths.jsOutputPath} -u 4`,
-  images: `npx copyfiles "${configPaths.digitalLandFrontendPath}digital-land-frontend/images/**/*.{png,ico}" ${configPaths.imagesOutputPath} -u 4`,
+  javascripts: `npx copyfiles "${configPaths.digitalLandFrontendPath}digital-land-frontend/javascripts/**/*.{js,json}" ${configPaths.jsOutputPath} -u 5`,
+  images: `npx copyfiles "${configPaths.digitalLandFrontendPath}digital-land-frontend/images/**/*.{png,ico}" ${configPaths.imagesOutputPath} -u 5`,
   govukAssets: `npx copyfiles -u 2 "${configPaths.govukFrontendPath}govuk/assets/**" ${configPaths.govukOutputPath}`
 }
 

--- a/package/package.json
+++ b/package/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@planning-data/digital-land-frontend",
   "description": "Digital Land Frontend components and assets",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "engines": {
     "node": ">= 4.2.0"
   },


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The scripts were copying files incorrectly because we now have an additional nested folder due to the use of `@planning-data` as the org name.

ref: https://www.npmjs.com/package/copyfiles#command-line

