### PR TITLE
Bump GOVUK Frontend versions 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Further information about versioning can be found in the [ReadME](/README.md#bumping-the-version).
 
+## [0.6.0] - 2025-08-13
+
+### Changed
+- Upgrade GOVUK frontend to 5.10.0
+- Upgrade GOVUK Jinja to 3.6.0
+
 ## [0.5.1] - 2025-06-13
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digital-land-frontend-repo",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "frontend components and assets for digital land",
   "engines": {
     "node": ">=16.0.0"
@@ -35,7 +35,7 @@
   "homepage": "https://github.com/digital-land/digital-land-frontend#readme",
   "devDependencies": {
     "copyfiles": "latest",
-    "govuk-frontend": "5.9.0",
+    "govuk-frontend": "5.10.0",
     "npm": "^8.3.0",
     "npm-run-all": "^4.1.5",
     "rollup": "^2.60.0",

--- a/package/package.json
+++ b/package/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@planning-data/digital-land-frontend",
   "description": "Digital Land Frontend components and assets",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "engines": {
     "node": ">= 4.2.0"
   },
@@ -24,7 +24,7 @@
     "browser-sync": "^2.27.7",
     "chokidar-cli": "^3.0.0",
     "copyfiles": "latest",
-    "govuk-frontend": "5.9.0",
+    "govuk-frontend": "5.10.0",
     "nps": "^5.10.0",
     "rollup": "^2.60.0",
     "sass": "^1.77.6",

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -12,7 +12,7 @@ click==8.1.7
     # via flask
 flask==3.0.0
     # via -r requirements/requirements.in
-govuk-frontend-jinja==3.5.0
+govuk-frontend-jinja==3.6.0
     # via digital-land-frontend
 gunicorn==21.2.0
     # via -r requirements/requirements.in

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ for directory in directories_jinja:
 
 setup(
     name="digital-land-frontend",
-    version="0.2.11",
+    version="0.6.0",
     author="Digital land",
     description="Reusable frontend code for digital land services and products",
     license="MIT",


### PR DESCRIPTION
### Changed
- Upgrade GOVUK frontend to 5.10.0
- Upgrade GOVUK Jinja to 3.6.0
